### PR TITLE
Test on floating Go versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.18', '1.19' ]
+        version: [ 'oldstable', 'stable' ]
     name: Go ${{ matrix.version }}
     outputs:
       pr_number: ${{ github.event.number }}
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.version }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: ./scripts/run-tests.sh
   call-dependabot-pr-workflow:
     needs: test


### PR DESCRIPTION
- go1.18 / go.19 are EOL
- Bump setup-go from v2 to v5
- Bump checkout from v2 to v4